### PR TITLE
Add CLAUDE.md and update README files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Documentation
+
+- [`README.md`](README.md) — project overview, hardware, system architecture
+- [`code/README.md`](code/README.md) — build instructions, code structure, architecture, naming conventions
+
+## Key Notes
+
+- `CMakeLists.txt` is in `code/`, not the repository root — run all build commands from there
+- No heap allocation in firmware; use `StaticList`, `RingBuffer`, and fixed-size arrays

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
-# Motor-Driver
+# ServoCore
+
+ServoCore is a full-stack closed-loop motor controller project, covering custom PCB hardware, embedded firmware, and a Windows host control library with a graphical dev tool.
+
+## System Overview
+
+```
+[ Dev Tool (Qt6 GUI) ]
+        |
+[ Control API (Windows) ]
+        |
+     Serial (UART)
+        |
+[ Firmware (RP2040 / RP2350) ]
+        |
+[ Motor + AS5600L Encoder ]
+```
+
+The firmware runs on the microcontroller, manages the motor, and reads position feedback from an AS5600L magnetic encoder. The host communicates with the device over a serial connection using a custom binary packet protocol. The dev tool provides a GUI for device discovery, parameter inspection, and control.
+
+## Hardware
+
+The target MCU is the **RP2350** (with internal flash). Development currently uses the **RP2040**.
+
+The motor position feedback uses an **AS5600L** magnetic encoder.
+
+PCB design (KiCad) lives in `ele/` — early stage, not yet complete.
+
+## Repository Structure
+
+```
+ele/        PCB schematic and layout (KiCad)
+code/       All software — firmware, host libraries, dev tool
+docs/       Datasheets and reference material
+```
+
+See [`code/README.md`](code/README.md) for build instructions and software architecture.

--- a/code/README.md
+++ b/code/README.md
@@ -1,36 +1,177 @@
-# About
+# Code
 
-# Building
+## About
 
-## Requirements
+Software for the ServoCore project. See the [root README](../README.md) for a project overview.
 
-- ARM gcc compiler / Arm GNU Toolchain
-    - The compiler can be downloaded
-      from [this link](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads).
-      Choose Bare-metal-target (arm-none-eabi) toolchain for your host platform
-    - The bin folder must be added to PATH
+## Building
 
-## Building directly with cmake
+### Requirements
 
-- TODO: ADD THESE INSTRUCTIONS
+- **Firmware builds only:** [Arm GNU Toolchain](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads) — choose the bare-metal target (`arm-none-eabi`) for your host platform and add its `bin/` to `PATH`.
+- **Dev tool (optional):** Qt6 (Core, Widgets, SerialPort). The dev tool is built as part of the host build when Qt6 is found — if not found it is skipped with a warning. Qt6 must be locatable by CMake; either add Qt's `bin/` to `PATH` or pass `-DCMAKE_PREFIX_PATH=<Qt install>/lib/cmake` at configure time (e.g. `C:\Qt\6.8.2\mingw_64\lib\cmake` on Windows).
 
-## Building with Clion IDE
+External dependencies (Pico SDK, GTest) are fetched automatically at configure time via `FetchContent`.
 
-- Open the code directory as Clion project
-- Pop up opens to configure Cmake profiles for the project
-    - If the popup does not open navigate: File -> Settings -> Build, Execution,
-      Deployment -> CMake
-- Create profile for both release and debug build:
-    - Name: ```Release / Debug```
-    - Build type: ```Release/ Debug```
-    - Toolchain: ```Use default (will be changed using cmake variable later)```
-    - Generator: ```Ninja```
-    - CMake options: 
-    - Build directory: ```your choice```
-    - Leave rest as it is
+### Building with CMake
 
+All commands run from the `code/` directory.
 
-- Add build configuration
-    - TODO: COMPLETE WITH DEBUGGER RUNNING AND SO ON
+**Host build** (control API + libraries, no ARM toolchain required):
+```bash
+cmake -B build
+cmake --build build
+```
 
-## List of CMake variables and options
+**Firmware build:**
+```bash
+cmake -B build_fw -DSERVO_CORE_FIRMWARE_BUILD=ON
+cmake --build build_fw
+```
+
+**Tests:**
+```bash
+cmake -B build_test -DSERVO_CORE_BUILD_TESTS=ON
+cmake --build build_test
+./build_test/debug_print_tests
+```
+
+### Building with CLion
+
+Open the `code/` directory as a CLion project. When prompted to configure CMake profiles (or via *File → Settings → Build, Execution, Deployment → CMake*), create profiles for the builds you need:
+
+**Host profile:**
+- Name: `Host-Release` / `Host-Debug`
+- Build type: `Release` / `Debug`
+- Generator: `Ninja`
+- CMake options: `-DCMAKE_PREFIX_PATH=C:\Qt\6.8.2\mingw_64\lib\cmake` *(adjust to your Qt install path)*
+
+**Firmware profile:**
+- Name: `Firmware-Release` / `Firmware-Debug`
+- Build type: `Release` / `Debug`
+- Toolchain: set to the ARM GNU toolchain
+- Generator: `Ninja`
+- CMake options: `-DSERVO_CORE_FIRMWARE_BUILD=ON`
+
+#### Debugging firmware with J-Link
+
+Add a run configuration for the embedded GDB server (*pull-down next to the build button → Edit Configurations → + → Embedded GDB Server*):
+
+| Field | Value |
+|-------|-------|
+| Name | `J-Link` |
+| Target remote args | `localhost:2331` |
+| GDB Server | path to `JLinkGDBServerCLExe` (e.g. `C:\Program Files\SEGGER\JLink\JLinkGDBServerCL.exe`) |
+| GDB Server args | `-if SWD -device RP2040_M0_0` |
+
+Running this configuration will flash and attach the debugger via J-Link.
+
+SVD files for peripheral register visualization are in `tools/`:
+
+| File | Use |
+|------|-----|
+| `tools/RP2040.svd` | Current development target |
+| `tools/RP2350.svd` | Final production target |
+
+Point the run configuration's SVD path to the appropriate file to get hardware register views in the debugger.
+
+### CMake options
+
+| Option | Default | Purpose |
+|--------|---------|---------|
+| `SERVO_CORE_FIRMWARE_BUILD` | OFF | Switch to firmware/ARM build |
+| `SERVO_CORE_BUILD_TESTS` | OFF | Enable GTest unit tests |
+| `ServoCore_ASSERT_LEVEL` | — | Assertion verbosity (0 = disabled, 3 = most verbose) |
+| `SERVO_CORE_CONTROL_API_WINDOWS_COMPORT_DRIVER_DEBUG_PRINTS` | OFF | Print all bytes passing through the serial driver |
+| `SERVO_CORE_DISABLE_SERIAL_COMMUNICATION_FRAMEWORK_TIMEOUTS` | OFF | Disable packet timeouts (debugging aid) |
+
+---
+
+## Structure
+
+```
+code/
+├── common/             # Shared between firmware and host
+│   ├── drivers/
+│   │   └── interfaces/ # Abstract driver interfaces (serial, LED, timer, clock)
+│   ├── libs/
+│   │   ├── serial_communication_framework/
+│   │   ├── parameter_system/
+│   │   ├── assert/
+│   │   ├── debug_print/
+│   │   ├── utils/      # RingBuffer, StaticList
+│   │   └── math/       # CRC
+│   └── protocol/       # Concrete command definitions
+├── firmware/           # Embedded application (RP2040 / RP2350)
+├── control_api/
+│   ├── template/       # Platform-agnostic master layer
+│   ├── windows/        # Windows implementation
+│   └── python/         # Python bindings (planned)
+└── dev_tool/           # Qt6 GUI for device control and parameter inspection
+```
+
+---
+
+## Architecture
+
+### Serial Communication Framework
+
+`common/libs/serial_communication_framework/`
+
+A binary packet protocol that runs over serial. The framework defines a type-safe command model — each command pairs a request type and a response type with an operation code, enforced at compile time.
+
+There are two sides: a **master** (host) that sends commands and waits for responses, and a **slave** (firmware) that receives commands, dispatches them to registered handlers, and responds. Both sides validate packets using a two-level CRC (header + payload).
+
+### Protocol
+
+`common/protocol/`
+
+The concrete set of commands the device supports — ping, parameter read/write, metadata queries, motor control, etc. Built on top of the serial communication framework.
+
+### Parameter System
+
+`common/libs/parameter_system/`
+
+A typed parameter system that lets the firmware expose device state and configuration to the host over the protocol. Parameters have a value type (e.g. `uint8`, `float`, `int32`), a name, and a read/write access level. There are three categories:
+
+- **Saved** — persists across reboots
+- **Runtime** — resets on reboot
+- **Signal** — read-only, device-generated (sensor data etc.)
+
+The host can enumerate all parameters, query their metadata, and read or write their values at runtime.
+
+### Control API
+
+`control_api/`
+
+The library used to communicate with a ServoCore device. The design is split into a platform-agnostic template layer and platform-specific implementations (currently Windows, Python bindings planned). The template layer is intentionally portable — it can run on a desktop host or be compiled for a microcontroller, so another MCU can act as the master and control the ServoCore board.
+
+### Firmware
+
+`firmware/`
+
+The embedded application running on the microcontroller. Handles hardware initialization, drives the motor, reads the encoder, and processes incoming protocol commands.
+
+Driver implementations are separated from the rest of the firmware via interfaces (`common/drivers/interfaces/`), keeping hardware-specific code isolated and the rest of the codebase portable.
+
+---
+
+## Conventions
+
+- `K_` prefix for compile-time constants.
+- `std::span<uint8_t>` for all buffer passing (zero-copy).
+- No heap allocation in firmware — use `StaticList`, `RingBuffer`, and fixed-size arrays.
+- Namespaces mirror the directory structure.
+
+### Naming
+
+| Thing | Convention | Example |
+|-------|-----------|---------|
+| Classes & types | `PascalCase` | `SlaveHandler` |
+| Interfaces | `PascalCase` + `Interface` suffix | `RgbLedInterface` |
+| Functions & methods | `camelCase` | `callMyGoodFunction` |
+| Variables | `snake_case` | `my_variable` |
+| Class members | `snake_case` + `_` suffix | `my_member_` |
+| Enum members | `snake_case` | `timed_out` |
+| Files (single class) | matches class name | `SlaveHandler.cpp` |
+| Files (broader/utility) | `snake_case` | `serialize_deserialize.cpp` |


### PR DESCRIPTION
- Add CLAUDE.md as a thin index pointing to human-readable docs
- Rewrite root README.md with project overview and system architecture
- Rewrite code/README.md with build instructions, CLion setup, J-Link debugging, code structure, architecture overview, and naming conventions